### PR TITLE
Added support for 256-color mode codes

### DIFF
--- a/lib/Parse/ANSIColor/Tiny.pm
+++ b/lib/Parse/ANSIColor/Tiny.pm
@@ -520,7 +520,7 @@ If you do find bugs please submit tickets (with patches, if possible).
 
 =for :list
 * L<Term::ANSIColor> - For marking up text that will be printed to the terminal
-* L<Image::TextMode> (and L<Image::TextMode::Format::ANSI>) - Successor to L<Image::ANSI>; Specifically designed for parsing ANSI art
+* L<Image::TextMode> (and L<Image::TextMode::Format::ANSI>) - Successor to C<Image::ANSI>; Specifically designed for parsing ANSI art
 * L<Term::VT102> - Handles more than colors and is likely more robust but may be overkill in simple situations (and was difficult to install in the past).
 * L<HTML::FromANSI::Tiny> - Uses this module to translate ANSI colored text to simple HTML
 

--- a/lib/Parse/ANSIColor/Tiny.pm
+++ b/lib/Parse/ANSIColor/Tiny.pm
@@ -150,8 +150,11 @@ sub split_with_extended
   }
 
   push @nums, $attrs =~ m{ 0*( [34]8;0*5;\d+ | \d+) (?: ; | \z ) | ;}xmsg;
-    
-  return map  { defined $_ ?  $_  : '0' } @nums;
+  return  
+      # remove leading zeros in color code
+      map { m/;/g ? s/0+(\d+)/\1/g : (); $_  }
+      # removed undefined with zero
+      map  { defined $_ ?  $_  : '0' } @nums;
 }
 
 =method identify

--- a/lib/Parse/ANSIColor/Tiny.pm
+++ b/lib/Parse/ANSIColor/Tiny.pm
@@ -150,7 +150,7 @@ sub split_with_extended
   }
 
   push @nums, $attrs =~ m{ 0*( [34]8;0*5;\d+ | \d+) (?: ; | \z ) | ;}xmsg;
-  return  
+  return
       # remove leading zeros in color code
       map { m/;/g ? s/0+(\d+)/$1/g : (); $_  }
       # removed undefined with zero

--- a/lib/Parse/ANSIColor/Tiny.pm
+++ b/lib/Parse/ANSIColor/Tiny.pm
@@ -152,7 +152,7 @@ sub split_with_extended
   push @nums, $attrs =~ m{ 0*( [34]8;0*5;\d+ | \d+) (?: ; | \z ) | ;}xmsg;
   return  
       # remove leading zeros in color code
-      map { m/;/g ? s/0+(\d+)/\1/g : (); $_  }
+      map { m/;/g ? s/0+(\d+)/$1/g : (); $_  }
       # removed undefined with zero
       map  { defined $_ ?  $_  : '0' } @nums;
 }

--- a/t/identify.t
+++ b/t/identify.t
@@ -32,5 +32,13 @@ eq_or_diff [$p->identify('31;0;0;1')], [qw(red clear clear bold)], 'code;zero;ze
 eq_or_diff [$p->identify('31;39')],     [qw(   red       reset_foreground)], 'fg color, fg reset';
 eq_or_diff [$p->identify('41;32;39')],  [qw(on_red green reset_foreground)], 'bg color, fg reset';
 eq_or_diff [$p->identify('41;49')],     [qw(on_red       reset_background)], 'bg color, bg reset';
+eq_or_diff [$p->identify('38;5;1')],     [qw(ansi1)], 'fg asni extended color';
+eq_or_diff [$p->identify('48;5;15')],     [qw(on_ansi15)], 'bg ansi extended color';
+eq_or_diff [$p->identify('38;5;124')],     [qw(rgb300)], 'fg extended color';
+eq_or_diff [$p->identify('48;5;230')],     [qw(on_rgb554)], 'extended color, color codes';
+eq_or_diff [$p->identify('38;5;64;0')],     [qw(rgb120 clear)], 'fg extended color;clear';
+eq_or_diff [$p->identify('48;5;14;0;38;5;45')],     [qw(on_ansi14 clear rgb045)], 'bg extended color; clear; fg extended color;clear';
+eq_or_diff [$p->identify('38;5;67;;38;5;86')],     [qw(rgb123 clear rgb154)], 'bg extended color; clear; fg extended color;clear';
+eq_or_diff [$p->identify('48;5;13;')],     [qw(on_ansi13 clear)], 'fg extended color;clear';
 
 done_testing;

--- a/t/identify.t
+++ b/t/identify.t
@@ -40,5 +40,6 @@ eq_or_diff [$p->identify('38;5;64;0')],     [qw(rgb120 clear)], 'fg extended col
 eq_or_diff [$p->identify('48;5;14;0;38;5;45')],     [qw(on_ansi14 clear rgb045)], 'bg extended color; clear; fg extended color;clear';
 eq_or_diff [$p->identify('38;5;67;;38;5;86')],     [qw(rgb123 clear rgb154)], 'bg extended color; clear; fg extended color;clear';
 eq_or_diff [$p->identify('48;5;13;')],     [qw(on_ansi13 clear)], 'fg extended color;clear';
+eq_or_diff [$p->identify('48;5;0017;')],     [qw(on_rgb001 clear)], 'fg extended color with leading zeros;clear';
 
 done_testing;


### PR DESCRIPTION
Now library can parse extended set foreground and foreground color codes, like ESC[38;5;<fgcode>m and ESC[48;5;<bgcode>m. Just mirror functionality from Term::ANSIColor, which already supports these codes.
Adds following codes:
    ansi(0 .. 15) and on_ansi(0..15) - codes for ANSI system colors
    rgb(0 .. 5)(0 .. 5)(0 ... 5) and  on_rgb(0 .. 5)(0 .. 5)(0 ... 5) -  for 256-color RGB colors
    grey(0 .. 23) - for 24 shades of grey.
